### PR TITLE
Updates for when all microservices are running on Liberty

### DIFF
--- a/microservice-speaker/src/main/java/io/microprofile/showcase/speaker/rest/Application.java
+++ b/microservice-speaker/src/main/java/io/microprofile/showcase/speaker/rest/Application.java
@@ -15,9 +15,6 @@ package io.microprofile.showcase.speaker.rest;
 
 
 import javax.ws.rs.ApplicationPath;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.Set;
 
 /**
  * Root REST application context
@@ -25,13 +22,4 @@ import java.util.Set;
 @ApplicationPath("/speaker")
 public class Application extends javax.ws.rs.core.Application {
 
-    /**
-     * The REST application resource classes
-     *
-     * @return Set of classes
-     */
-    @Override
-    public Set<Class<?>> getClasses() {
-        return new HashSet<>(Collections.singletonList(ResourceSpeaker.class));
-    }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,7 @@
         <version.payara>4.1.1.163</version.payara>
         <version.tomee>7.0.1</version.tomee>
         <version.wildfly>10.0.0.Final</version.wildfly>
-        <version.liberty>16.0.0.3</version.liberty>
+        <version.liberty>17.0.0.2</version.liberty>
 
         <!-- Dependencies -->
         <version.javaee>7.0</version.javaee>


### PR DESCRIPTION
Fixes 2 issues when running all microservices with Liberty.

# Issue 1
Speakers UI does not load because CORS filter did not apply `Access-Control-Allow-Origin` header.  Fixed by including CORS filter in the jax-rs app (i.e. let jax-rs figure out app packaging on its own)

# Issue 2
NPE from JAX-RS.  Fixed by upgrading to Liberty 17.0.0.2)

```
Caused by: java.lang.NullPointerException
	at io.microprofile.showcase.speaker.rest.ResourceSpeaker.getUri(ResourceSpeaker.java:115)
	at io.microprofile.showcase.speaker.rest.ResourceSpeaker.addHyperMedia(ResourceSpeaker.java:100)
	at io.microprofile.showcase.speaker.rest.ResourceSpeaker$$Lambda$8.0000000003BD3D70.accept(Unknown Source)
	at java.util.ArrayList.forEach(ArrayList.java:1260)
	at io.microprofile.showcase.speaker.rest.ResourceSpeaker.retrieveAll(ResourceSpeaker.java:56)
	at io.microprofile.showcase.speaker.rest.ResourceSpeaker$Proxy$_$$_WeldClientProxy.retrieveAll(Unknown Source)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:95)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:55)
	at java.lang.reflect.Method.invoke(Method.java:507)
	at com.ibm.ws.jaxrs20.server.LibertyJaxRsServerFactoryBean.performInvocation(LibertyJaxRsServerFactoryBean.java:651)
	at com.ibm.ws.jaxrs20.server.LibertyJaxRsInvoker.performInvocation(LibertyJaxRsInvoker.java:115)
	at org.apache.cxf.service.invoker.AbstractInvoker.invoke(AbstractInvoker.java:97)
	... 35 more
```