### PR TITLE
Use microprofile:1.0 maven dependency instead of javaee-api:7.0

### DIFF
--- a/demo-bootstrap/pom.xml
+++ b/demo-bootstrap/pom.xml
@@ -30,13 +30,7 @@
     <packaging>jar</packaging>
 
     <dependencies>
-
-        <dependency>
-            <groupId>javax</groupId>
-            <artifactId>javaee-api</artifactId>
-            <scope>provided</scope>
-        </dependency>
-
+        
         <dependency>
             <groupId>org.glassfish</groupId>
             <artifactId>javax.json</artifactId>

--- a/microservice-schedule/pom.xml
+++ b/microservice-schedule/pom.xml
@@ -86,10 +86,6 @@
 
     <dependencies>
         <dependency>
-            <groupId>javax</groupId>
-            <artifactId>javaee-api</artifactId>
-        </dependency>
-        <dependency>
             <groupId>io.microprofile.showcase</groupId>
             <artifactId>demo-bootstrap</artifactId>
             <version>${project.version}</version>

--- a/microservice-session/pom.xml
+++ b/microservice-session/pom.xml
@@ -157,12 +157,6 @@
 
     <dependencies>
         <dependency>
-            <groupId>javax</groupId>
-            <artifactId>javaee-api</artifactId>
-            <scope>provided</scope>
-        </dependency>
-
-        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
             <version>2.8.2</version>

--- a/microservice-speaker/pom.xml
+++ b/microservice-speaker/pom.xml
@@ -191,13 +191,6 @@
             <version>${project.version}</version>
         </dependency>
 
-        <!-- JAVA EE -->
-        <dependency>
-            <groupId>org.apache.tomee</groupId>
-            <artifactId>javaee-api</artifactId>
-            <scope>provided</scope>
-        </dependency>
-
         <!--3RD PARTY-->
         <dependency>
             <groupId>org.codehaus.swizzle</groupId>

--- a/microservice-vote/pom.xml
+++ b/microservice-vote/pom.xml
@@ -154,13 +154,6 @@
     <dependencies>
         <dependency>
             <groupId>net.wasdev.wlp.starters.microprofile</groupId>
-            <artifactId>provided-pom</artifactId>
-            <version>0.0.1-SNAPSHOT</version>
-            <type>pom</type>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>net.wasdev.wlp.starters.microprofile</groupId>
             <artifactId>runtime-pom</artifactId>
             <version>0.0.1-SNAPSHOT</version>
             <type>pom</type>

--- a/pom.xml
+++ b/pom.xml
@@ -113,7 +113,7 @@
         <version.liberty>16.0.0.3</version.liberty>
 
         <!-- Dependencies -->
-        <version.javaee>7.0</version.javaee>
+        <version.microprofile>1.0.0</version.microprofile>
         <version.resteasy>3.0.19.Final</version.resteasy>
         <version.swagger>1.5.10</version.swagger>
         <version.swizzle-stream>1.6.2</version.swizzle-stream>
@@ -138,17 +138,13 @@
 
     <dependencyManagement>
         <dependencies>
-            <!-- JAVA EE -->
+            <!-- MicroProfile -->
             <dependency>
-                <groupId>javax</groupId>
-                <artifactId>javaee-api</artifactId>
-                <version>${version.javaee}</version>
+                <groupId>io.microprofile</groupId>
+                <artifactId>microprofile</artifactId>
+                <version>${version.microprofile}</version>
+                <type>pom</type>
                 <scope>provided</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.tomee</groupId>
-                <artifactId>javaee-api</artifactId>
-                <version>${version.javaee}</version>
             </dependency>
 
             <!-- WILDFLY SWARM -->
@@ -280,6 +276,12 @@
     </dependencyManagement>
 
     <dependencies>
+        <dependency>
+            <groupId>io.microprofile</groupId>
+            <artifactId>microprofile</artifactId>
+            <type>pom</type>
+            <scope>provided</scope>
+        </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
@@ -444,38 +446,6 @@
                 </plugin>
             </plugins>
         </pluginManagement>
-
-        <!--<plugins>-->
-        <!--<plugin>-->
-        <!--<groupId>org.codehaus.mojo</groupId>-->
-        <!--<artifactId>license-maven-plugin</artifactId>-->
-        <!--<executions>-->
-        <!--<execution>-->
-        <!--<id>first</id>-->
-        <!--<goals>-->
-        <!--<goal>update-file-header</goal>-->
-        <!--</goals>-->
-        <!--<phase>process-sources</phase>-->
-        <!--<configuration>-->
-        <!--<licenseName>apache_v2</licenseName>-->
-        <!--<excludes>-->
-        <!--<exclude>*.png</exclude>-->
-        <!--</excludes>-->
-        <!--</configuration>-->
-        <!--</execution>-->
-        <!--<execution>-->
-        <!--<id>download-licenses</id>-->
-        <!--<goals>-->
-        <!--<goal>download-licenses</goal>-->
-        <!--</goals>-->
-        <!--</execution>-->
-        <!--</executions>-->
-        <!--<configuration>-->
-        <!--<licenseName>apache_v2</licenseName>-->
-        <!--</configuration>-->
-
-        <!--</plugin>-->
-        <!--</plugins>-->
     </build>
 
     <profiles>

--- a/web-application/pom.xml
+++ b/web-application/pom.xml
@@ -172,8 +172,9 @@
 
                 <!--PROVIDED-->
                 <dependency>
-                    <groupId>org.apache.tomee</groupId>
-                    <artifactId>javaee-api</artifactId>
+                    <groupId>javax.servlet</groupId>
+                    <artifactId>javax.servlet-api</artifactId>
+                    <version>3.1.0</version>
                     <scope>provided</scope>
                 </dependency>
                 <dependency>


### PR DESCRIPTION
Maven dependencies can be cleaned up a bit to pull in only the Microprofile 1.0 dependencies, instead of all of Java EE 7.0.  This will also allow us to more easily update the repo to use newer MP APIs as they are released and start diverging from what is available in Java EE (e.g. MP-Config)