### PR TITLE
Add mpMetrics to Vote microservice

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -10,7 +10,7 @@ The application consists of several Microservices and a Web-Application managing
 | link:/microservice-schedule/README.adoc[microservice-schedule] | https://www.payara.fish/payara_micro[Payara Micro] | Schedule of the conference | JAX-RS, CDI 
 | link:/microservice-session/README.adoc[microservice-session] | http://wildfly-swarm.io/[WildFly Swarm] | Sessions of the conference | JAX-RS, CDI, JSON-P
 | link:/microservice-speaker/readme.adoc[microservice-speaker] | http://tomee.apache.org/[Apache TomEE] | Speakers of the conference | JAX-RS, CDI, JSON
-| link:/microservice-vote/README.adoc[microservice-vote] | https://developer.ibm.com/wasdev/[WebSphere Liberty] | Votes for each session | JAX-RS, CDI, JSON-P, MP Config, MP Fault Tolerance
+| link:/microservice-vote/README.adoc[microservice-vote] | https://developer.ibm.com/wasdev/[WebSphere Liberty] | Votes for each session | JAX-RS, CDI, JSON-P, MP Config, MP Fault Tolerance, MP Metrics
 | link:/web-application/readme.adoc[web-application] |  http://tomee.apache.org/[Apache TomEE] | Frontend UI | Angular2, Bootstrap4
 |=====
 

--- a/microservice-vote/README.adoc
+++ b/microservice-vote/README.adoc
@@ -35,6 +35,8 @@ GET    /vote/ratingsByAttendee        # Get all votes made by attendee ID
 ** automatically retry failed operations using `@Retry`
 ** limit the maximum resources allocated to parallel operations using `@Bulkhead`
 * *CouchDB* is a NoSQL database.  It's not part of MicroProfile, but is used here to persist vote information
+* *MicroProfile Metrics* is used to gather metrics about the time it takes the HashMapDAO objects to complete their operations, and to keep a count of the amount of times each REST endpoint is requested
+** The metrics are available to view at https://localhost:9443/metrics. Sending a request that accepts `application/json` will receive a JSON response, otherwise a Prometheus-formatted response will be sent
 
 == Build and run the service
 ```

--- a/microservice-vote/src/main/java/io/microprofile/showcase/vote/api/SessionVote.java
+++ b/microservice-vote/src/main/java/io/microprofile/showcase/vote/api/SessionVote.java
@@ -36,6 +36,8 @@ import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 
+import org.eclipse.microprofile.metrics.annotation.Counted;
+
 import io.microprofile.showcase.vote.model.Attendee;
 import io.microprofile.showcase.vote.model.SessionRating;
 import io.microprofile.showcase.vote.persistence.AttendeeDAO;
@@ -47,6 +49,7 @@ import io.microprofile.showcase.vote.utils.Log;
 @ApplicationScoped
 @Path("/")
 @Log
+@Counted(monotonic=true, displayName="Endpoint hit count", description="The amount of times this endpoint has been requested since starting the server.")
 public class SessionVote {
 
     private @Inject @NonPersistent AttendeeDAO hashMapAttendeeDAO;

--- a/microservice-vote/src/main/java/io/microprofile/showcase/vote/persistence/HashMapAttendeeDAO.java
+++ b/microservice-vote/src/main/java/io/microprofile/showcase/vote/persistence/HashMapAttendeeDAO.java
@@ -22,10 +22,13 @@ import java.util.concurrent.ConcurrentMap;
 
 import javax.enterprise.context.ApplicationScoped;
 
+import org.eclipse.microprofile.metrics.annotation.Timed;
+
 import io.microprofile.showcase.vote.model.Attendee;
 
 @ApplicationScoped
 @NonPersistent
+@Timed(displayName="Data Layer Times", description="The time it takes this DAO method to complete, as a histogram.")
 public class HashMapAttendeeDAO implements AttendeeDAO {
 
     private ConcurrentMap<String, Attendee> attendees = new ConcurrentHashMap<String, Attendee>();

--- a/microservice-vote/src/main/java/io/microprofile/showcase/vote/persistence/HashMapSessionRatingDAO.java
+++ b/microservice-vote/src/main/java/io/microprofile/showcase/vote/persistence/HashMapSessionRatingDAO.java
@@ -31,11 +31,14 @@ import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
+import org.eclipse.microprofile.metrics.annotation.Timed;
+
 import io.microprofile.showcase.bootstrap.BootstrapData;
 import io.microprofile.showcase.vote.model.SessionRating;
 
 @ApplicationScoped
 @NonPersistent
+@Timed(displayName="Data Layer Times", description="The time it takes this DAO method to complete, as a histogram.")
 public class HashMapSessionRatingDAO implements SessionRatingDAO {
 
     private ConcurrentMap<String, SessionRating> allRatings = new ConcurrentHashMap<String, SessionRating>();

--- a/microservice-vote/src/main/java/io/microprofile/showcase/vote/persistence/couch/CouchAttendeeDAO.java
+++ b/microservice-vote/src/main/java/io/microprofile/showcase/vote/persistence/couch/CouchAttendeeDAO.java
@@ -31,6 +31,8 @@ import org.eclipse.microprofile.faulttolerance.Bulkhead;
 import org.eclipse.microprofile.faulttolerance.Retry;
 import org.eclipse.microprofile.faulttolerance.Timeout;
 
+import org.eclipse.microprofile.metrics.annotation.Timed;
+
 import io.microprofile.showcase.vote.model.Attendee;
 import io.microprofile.showcase.vote.persistence.AttendeeDAO;
 import io.microprofile.showcase.vote.persistence.Persistent;

--- a/microservice-vote/src/main/java/io/microprofile/showcase/vote/persistence/couch/CouchSessionRatingDAO.java
+++ b/microservice-vote/src/main/java/io/microprofile/showcase/vote/persistence/couch/CouchSessionRatingDAO.java
@@ -30,6 +30,8 @@ import org.eclipse.microprofile.faulttolerance.Asynchronous;
 import org.eclipse.microprofile.faulttolerance.Bulkhead;
 import org.eclipse.microprofile.faulttolerance.Timeout;
 
+import org.eclipse.microprofile.metrics.annotation.Timed;
+
 import io.microprofile.showcase.vote.model.Attendee;
 import io.microprofile.showcase.vote.model.SessionRating;
 import io.microprofile.showcase.vote.persistence.Persistent;

--- a/microservice-vote/src/main/liberty/config/server.xml
+++ b/microservice-vote/src/main/liberty/config/server.xml
@@ -26,6 +26,7 @@
     <featureManager>
         <feature>mpConfig-1.1</feature>
         <feature>mpFaultTolerance-1.0</feature>
+        <feature>mpMetrics-1.0</feature>
     </featureManager>
 
     <httpEndpoint httpPort="${default.http.port}" httpsPort="${default.https.port}" id="defaultHttpEndpoint"/>
@@ -33,6 +34,9 @@
     <jndiEntry jndiName="cloudant/url" value="${env.CLOUDANT_URL}"/>
     <jndiEntry jndiName="cloudant/username" value="${env.CLOUDANT_USERNAME}"/>
     <jndiEntry jndiName="cloudant/password" value="${env.CLOUDANT_PASSWORD}"/>
+    
+    <quickStartSecurity userName="confAdmin" userPassword="microprofile"/>
+	<keyStore id="defaultKeyStore" password="mpKeystore"/>
 
 	<!-- Automatically expand WAR files and EAR files -->
 	<applicationManager autoExpand="true"/>

--- a/web-application/src/main/static/app/vote/votes.component.html
+++ b/web-application/src/main/static/app/vote/votes.component.html
@@ -17,6 +17,9 @@
         <div class="col-xs">
             <h3>{{title}}</h3>
         </div>
+        <div class="col-xs">
+                <p class="text-sm-right"><a href="https://localhost:9443/metrics/" target="_BLANK" title="Consume with Prometheus or your favorite JSON processor">System Stats by Microprofile Metrics</a></p>
+        </div>
     </div>
     <div class="row">
         <div class="col-xs">


### PR DESCRIPTION
This adds the mpMetrics-1.0 feature to the Liberty server and adds metrics to several example locations.

It uses a `Timer` through the `@Timed` annotation to measure the time each HashMapDAO method takes. It stores these values in a histogram so trends can be seen. It also uses a `Counter` through the `@Counted` annotation to count the number of times each REST endpoint has been requested since the server has started. In addition, a suite of base metrics about the server are collected by default.

The data collected by all of these metrics can be accessed from the /metrics endpoint, which is linked from the Votes page of the web application. By default, it is output in a format known to Prometheus; however, if the endpoint is requested with `Accept: application/json` in the header, JSON will be sent.