### PR TITLE
Indicate installDir for when running all svcs on Liberty

### DIFF
--- a/microservice-schedule/pom.xml
+++ b/microservice-schedule/pom.xml
@@ -230,6 +230,7 @@
                            <serverName>scheduleServer</serverName>
                            <appArchive>${project.build.directory}/${warfile.name}.war</appArchive>
                            <configFile>${basedir}/src/main/liberty/config/server.xml</configFile>
+                           <assemblyInstallDirectory>${project.build.directory}</assemblyInstallDirectory>
                        </configuration>
                    </plugin>
                 </plugins>

--- a/microservice-session/pom.xml
+++ b/microservice-session/pom.xml
@@ -146,8 +146,9 @@
                        </executions>
                        <configuration>
                            <serverName>sessionServer</serverName>
+                           <assemblyInstallDirectory>${project.build.directory}</assemblyInstallDirectory>
+                           <configFile>src/main/liberty/config/server.xml</configFile>
                            <appArchive>${project.build.directory}/${warfile.name}.war</appArchive>
-                           <configFile>${basedir}/src/main/liberty/config/server.xml</configFile>
                        </configuration>
                    </plugin>
                 </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@
         <version.surefire.plugin>2.19.1</version.surefire.plugin>
         <version.war.plugin>2.6</version.war.plugin>
         <version.fabric8.plugin>3.1.83</version.fabric8.plugin>
-        <version.liberty.plugin>1.2.1</version.liberty.plugin>
+        <version.liberty.plugin>2.0</version.liberty.plugin>
 
         <!-- Test -->
         <version.arquillian>1.1.11.Final</version.arquillian>


### PR DESCRIPTION
Fixes an issue where building and running all microservices with Liberty fails with:

> CWWKM2004E: When installDir is set, it must point to a directory that contains lib/ws-launch.jar.

Signed-off-by: Andrew Guibert <andy.guibert@gmail.com>