### PR TITLE
Update liberty dependencies to 17.0.0.4

### DIFF
--- a/microservice-schedule/src/main/liberty/config/server.xml
+++ b/microservice-schedule/src/main/liberty/config/server.xml
@@ -14,7 +14,7 @@
 
 <server description="Schedule server">
     <featureManager>
-        <feature>microProfile-1.0</feature>
+        <feature>microProfile-1.2</feature>
     </featureManager>
 
     <httpEndpoint id="defaultHttpEndpoint" host="*" httpPort="6060" />

--- a/microservice-session/src/main/liberty/config/server.xml
+++ b/microservice-session/src/main/liberty/config/server.xml
@@ -14,7 +14,7 @@
 
 <server description="Session server">
     <featureManager>
-        <feature>microProfile-1.0</feature>
+        <feature>microProfile-1.2</feature>
     </featureManager>
 
     <httpEndpoint id="defaultHttpEndpoint" host="*" httpPort="5050" />

--- a/microservice-speaker/src/main/liberty/config/server.xml
+++ b/microservice-speaker/src/main/liberty/config/server.xml
@@ -14,7 +14,7 @@
 
 <server description="Speaker server">
     <featureManager>
-        <feature>microProfile-1.0</feature>
+        <feature>microProfile-1.2</feature>
     </featureManager>
 
     <httpEndpoint id="defaultHttpEndpoint" host="*" httpPort="4040" />

--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@
         <version.surefire.plugin>2.19.1</version.surefire.plugin>
         <version.war.plugin>2.6</version.war.plugin>
         <version.fabric8.plugin>3.1.83</version.fabric8.plugin>
-        <version.liberty.plugin>2.0</version.liberty.plugin>
+        <version.liberty.plugin>2.1</version.liberty.plugin>
 
         <!-- Test -->
         <version.arquillian>1.1.11.Final</version.arquillian>
@@ -111,7 +111,7 @@
         <version.payara.embedded>4.1.2.173.0.1</version.payara.embedded>
         <version.tomee>7.0.1</version.tomee>
         <version.wildfly>10.0.0.Final</version.wildfly>
-        <version.liberty>2017.9.0_1</version.liberty>
+        <version.liberty>17.0.0_04</version.liberty>
 
         <!-- Dependencies -->
         <version.microprofile>1.2</version.microprofile>
@@ -438,7 +438,7 @@
                     <version>${version.liberty.plugin}</version>
                     <configuration>
              			<install>
-                        	<type>webProfile7</type>
+                        	<type>microProfile1</type>
                         	<version>${version.liberty}</version>
                    		</install>
                     </configuration>


### PR DESCRIPTION
Currently building the project is broken because the pom.xml depends on a Liberty beta version (2017.9.0.0) which was necessary to get an early preview of MicroProfile features, but has since been removed from IBM repositories, as they only keep the 2 most recent betas available.

To resolve this, update dependencies to 17.0.0.4 which is an official Liberty release that contains the necessary MicroProfile features.  Also, since is is an official release, it will never be removed from IBM repositories.  