### PR TITLE
Update microprofile-session to Thorntail

### DIFF
--- a/microservice-session/pom.xml
+++ b/microservice-session/pom.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!--
+<?xml version="1.0" encoding="UTF-8" standalone="no"?><!--
   ~ Copyright(c) 2016-2017 IBM, Red Hat, and others.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,10 +10,7 @@
   ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
-  -->
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  --><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
 
@@ -41,8 +37,8 @@
 
         <plugins>
             <plugin>
-                <groupId>org.wildfly.swarm</groupId>
-                <artifactId>wildfly-swarm-plugin</artifactId>
+                <groupId>io.thorntail</groupId>
+                <artifactId>thorntail-maven-plugin</artifactId>
             </plugin>
         </plugins>
     </build>
@@ -171,7 +167,7 @@
         </dependency>
 
         <dependency>
-            <groupId>org.wildfly.swarm</groupId>
+            <groupId>io.thorntail</groupId>
             <artifactId>microprofile</artifactId>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -106,7 +106,7 @@
         <version.jackson>2.8.2</version.jackson>
 
         <!-- App servers -->
-        <version.wildfly-swarm>2017.2.0</version.wildfly-swarm>
+        <version.thorntail>2.6.0.Final</version.thorntail>
         <version.payara>4.1.2.173</version.payara>
         <version.payara.embedded>4.1.2.173.0.1</version.payara.embedded>
         <version.tomee>7.0.1</version.tomee>
@@ -142,19 +142,19 @@
             <!-- MicroProfile -->
             <dependency>
                 <groupId>org.eclipse.microprofile</groupId>
-                <artifactId>microprofile</artifactId>                
+                <artifactId>microprofile</artifactId>
                 <version>${version.microprofile}</version>
                 <type>pom</type>
                 <scope>provided</scope>
             </dependency>
 
-            <!-- WILDFLY SWARM -->
+            <!-- THORNTAIL -->
             <dependency>
-                <groupId>org.wildfly.swarm</groupId>
+                <groupId>io.thorntail</groupId>
                 <artifactId>bom-all</artifactId>
-                <version>${version.wildfly-swarm}</version>
-                <type>pom</type>
+                <version>${version.thorntail}</version>
                 <scope>import</scope>
+                <type>pom</type>
             </dependency>
 
             <!-- TOMEE -->
@@ -279,7 +279,7 @@
     <dependencies>
         <dependency>
             <groupId>org.eclipse.microprofile</groupId>
-            <artifactId>microprofile</artifactId>            
+            <artifactId>microprofile</artifactId>
             <type>pom</type>
             <scope>provided</scope>
         </dependency>
@@ -405,12 +405,10 @@
                     </configuration>
                 </plugin>
                 <plugin>
-                    <groupId>org.wildfly.swarm</groupId>
-                    <artifactId>wildfly-swarm-plugin</artifactId>
-                    <version>${version.wildfly-swarm}</version>
+                    <groupId>io.thorntail</groupId>
+                    <artifactId>thorntail-maven-plugin</artifactId>
                     <executions>
                         <execution>
-                            <id>package</id>
                             <goals>
                                 <goal>package</goal>
                             </goals>


### PR DESCRIPTION
I have a student which will be transforming this project (microprofile-session) to the Quarkus runtime. However, the original WildFly swarm based service no longer compiles so I moved it to Thorntail (updated WildFly swarm) so the student can work with it.